### PR TITLE
Allow push plugin to intercept messages; remove FirebaseMessagingService

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,11 +27,6 @@
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <activity android:name="com.appboy.ui.activities.AppboyFeedActivity" />
       <activity android:name="com.appboy.ui.AppboyWebViewActivity"/>
-      <service android:name="com.appboy.AppboyFirebaseMessagingService">
-        <intent-filter>
-          <action android:name="com.google.firebase.MESSAGING_EVENT" />
-        </intent-filter>
-      </service>
     </config-file>
   </platform>
 


### PR DESCRIPTION
This re-applies the following commit:

https://github.com/sanvello/appboy-cordova-sdk/commit/26057eb163ab0a636a5ca410ad3aab81d4596b40#diff-6813833f33103dfcaa583d4f09e06dc84c0ce8ddd34c8b567b56c9728be58389

The AppboyFirebaseMessagingService was unintentionally re-introduced
when merging the upstream branch as part of the Braze SDK update:

https://github.com/sanvello/appboy-cordova-sdk/commit/a848f5787bd82d5c165874c4c8dfc98f44760b63